### PR TITLE
fix: ConfettiExplosion in <cfp-submission-btn> caused horizontal overflow

### DIFF
--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -66,6 +66,7 @@ strong
 a
   color: #fff
 .maze-background
+  overflow-x: hidden // prevent ConfettiExplosion in cfp page causing horizontal overflow
   background-color: #333333
   background-image: url(/imgs/cfp/cfp_maze_pattern.png)
   background-size: 120vw auto


### PR DESCRIPTION
原本的爆炸特效會讓頁面出現橫向 scrollbar，如影片:

https://user-images.githubusercontent.com/18533304/170185810-173eba80-5313-453b-8b57-7cbce650fab7.mp4